### PR TITLE
Update .gitignore for common CMake output dir and Umiko configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ bin/
 obj/
 sln/
 tmp/
+configs/
+build/
 
 pmk/premake*
 
@@ -9,3 +11,5 @@ res/
 !res/commands.json
 
 scripts/run.sh
+
+umiko.service


### PR DESCRIPTION
Fixes the following:
  - `mkdir build; cmake -Bbuild` needs `build/` to be gitignored to avoid untracked file spam or potential committing of build files.
  - Umiko will generate a `configs/` directory to hold configuration and this is also not currently gitignored.